### PR TITLE
getenv() => environ[]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .pytest_cache/
 .DS_Store
 *.pem
+docker-build

--- a/speid/helpers/callback_helper.py
+++ b/speid/helpers/callback_helper.py
@@ -3,9 +3,9 @@ import json
 import requests
 from requests.auth import HTTPBasicAuth
 
-CALLBACK_URL = os.getenv('CALLBACK_URL')
-CALLBACK_API_KEY = os.getenv('CALLBACK_API_KEY')
-CALLBACK_API_SECRET = os.getenv('CALLBACK_API_SECRET')
+CALLBACK_URL = os.environ['CALLBACK_URL']
+CALLBACK_API_KEY = os.environ['CALLBACK_API_KEY']
+CALLBACK_API_SECRET = os.environ['CALLBACK_API_SECRET']
 
 
 def send_transaction(transaction):


### PR DESCRIPTION
- using `os.environ['VAR_NAME'] ensures there's an explicit error if the env var isn't defined. Otherwise, it'll use `None` and fail later
- remove `docker-build` from repo