### PR TITLE
Add outgoing transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean-pyc:
 		find . -name '*~' -delete
 
 test: clean-pyc lint
-		pytest -vv
+		pytest --cov-report term-missing tests/ --cov=speid
 		coveralls
 
 travis-test:

--- a/speid/models/transaction.py
+++ b/speid/models/transaction.py
@@ -98,7 +98,7 @@ class Transaction(Document, BaseModel):
             # The Unique-Sparse index skips over any document that is missing
             # the indexed field (null values)
             {'fields': ['+compound_key'], 'unique': True, 'sparse': True},
-        ],
+        ]
     }
 
     def set_state(self, state: Estado):

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -2,7 +2,7 @@ from mongoengine import DoesNotExist
 from sentry_sdk import capture_exception
 
 from speid.helpers import callback_helper, transaction_helper
-from speid.models import Transaction, Event
+from speid.models import Event, Transaction
 from speid.tasks import celery
 from speid.types import Estado, EventType
 

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -8,15 +8,15 @@ from speid.types import Estado, EventType
 
 
 @celery.task(bind=True, max_retries=5)
-def create_transactions(self, transactions: list):
+def create_incoming_transactions(self, transactions: list):
     try:
-        execute_create_transactions(transactions)
+        execute_create_incoming_transactions(transactions)
     except Exception as e:
         capture_exception(e)
         self.retry(countdown=600, exc=e)
 
 
-def execute_create_transactions(transactions: list):
+def execute_create_incoming_transactions(transactions: list):
     for transaction in transactions:
         try:
             previous_transaction = Transaction.objects.get(

--- a/tests/tasks/test_accounts.py
+++ b/tests/tasks/test_accounts.py
@@ -100,7 +100,7 @@ def test_create_account_existing_succeeded_account():
 @patch('speid.tasks.accounts.capture_exception')
 @patch('speid.tasks.accounts.create_account.retry')
 def test_does_not_retry_when_validation_error_raised(
-    mock_retry: MagicMock, mock_capture_exception: MagicMock,
+    mock_retry: MagicMock, mock_capture_exception: MagicMock
 ) -> None:
     account_dict = dict(
         nombre='Ricardo',
@@ -118,7 +118,7 @@ def test_does_not_retry_when_validation_error_raised(
 @patch('speid.tasks.accounts.capture_exception')
 @patch('speid.tasks.accounts.create_account.retry')
 def test_does_not_retry_when_invalid_rfc_raised(
-    mock_retry: MagicMock, mock_capture_exception: MagicMock,
+    mock_retry: MagicMock, mock_capture_exception: MagicMock
 ) -> None:
     account_dict = dict(
         nombre='24',

--- a/tests/tasks/test_transactions.py
+++ b/tests/tasks/test_transactions.py
@@ -4,7 +4,7 @@ import pytest
 
 from speid.models import Transaction
 from speid.tasks.transactions import (
-    execute_create_transactions,
+    execute_create_incoming_transactions,
     process_outgoing_transactions,
 )
 from speid.types import Estado
@@ -82,7 +82,7 @@ def outgoing_transaction():
 
 @pytest.mark.vcr
 def test_transaction_not_in_speid(incoming_transactions):
-    execute_create_transactions(incoming_transactions)
+    execute_create_incoming_transactions(incoming_transactions)
 
     saved_transaction = Transaction.objects.get(
         clave_rastreo=incoming_transactions[0]['ClaveRastreo']
@@ -92,7 +92,7 @@ def test_transaction_not_in_speid(incoming_transactions):
 
 @pytest.mark.vcr
 def test_transaction_not_in_backend_but_in_speid(incoming_transactions):
-    execute_create_transactions(incoming_transactions)
+    execute_create_incoming_transactions(incoming_transactions)
 
     saved_transaction = Transaction.objects.get(
         clave_rastreo=incoming_transactions[0]['ClaveRastreo']
@@ -102,7 +102,7 @@ def test_transaction_not_in_backend_but_in_speid(incoming_transactions):
     saved_transaction.estado = Estado.error
     saved_transaction.save()
 
-    execute_create_transactions([incoming_transactions[0]])
+    execute_create_incoming_transactions([incoming_transactions[0]])
 
     sent_transaction = Transaction.objects.get(
         clave_rastreo=saved_transaction.clave_rastreo

--- a/tests/tasks/test_transactions.py
+++ b/tests/tasks/test_transactions.py
@@ -1,8 +1,10 @@
 import pytest
+import datetime as dt
 
 from speid.models import Transaction
-from speid.tasks.transactions import execute
+from speid.tasks.transactions import execute_create_transactions, process_outgoing_transactions
 from speid.types import Estado
+from speid.validations import SpeidTransaction
 
 
 @pytest.fixture
@@ -49,9 +51,34 @@ def incoming_transactions():
     Transaction.objects.delete()
 
 
+@pytest.fixture
+def outgoing_transaction():
+    transaction_values = dict(
+        concepto_pago='PRUEBA',
+        institucion_ordenante='90646',
+        cuenta_beneficiario='072691004495711499',
+        institucion_beneficiaria='40072',
+        monto=2511,
+        nombre_beneficiario='Ricardo Sánchez',
+        tipo_cuenta_beneficiario=40,
+        nombre_ordenante='BANCO',
+        cuenta_ordenante='646180157000000004',
+        rfc_curp_ordenante='ND',
+        speid_id='go' + dt.datetime.now().strftime('%m%d%H%M%S'),
+        version=1,
+    )
+    transaction_val = SpeidTransaction(**transaction_values)
+    transaction = transaction_val.transform()
+    transaction.save()
+
+    yield transaction
+
+    transaction.delete()
+
+
 @pytest.mark.vcr
 def test_transaction_not_in_speid(incoming_transactions):
-    execute(incoming_transactions)
+    execute_create_transactions(incoming_transactions)
 
     saved_transaction = Transaction.objects.get(
         clave_rastreo=incoming_transactions[0]['ClaveRastreo']
@@ -61,8 +88,7 @@ def test_transaction_not_in_speid(incoming_transactions):
 
 @pytest.mark.vcr
 def test_transaction_not_in_backend_but_in_speid(incoming_transactions):
-
-    execute(incoming_transactions)
+    execute_create_transactions(incoming_transactions)
 
     saved_transaction = Transaction.objects.get(
         clave_rastreo=incoming_transactions[0]['ClaveRastreo']
@@ -72,10 +98,52 @@ def test_transaction_not_in_backend_but_in_speid(incoming_transactions):
     saved_transaction.estado = Estado.error
     saved_transaction.save()
 
-    execute([incoming_transactions[0]])
+    execute_create_transactions([incoming_transactions[0]])
 
     sent_transaction = Transaction.objects.get(
         clave_rastreo=saved_transaction.clave_rastreo
     )
 
     assert sent_transaction.estado == Estado.succeeded
+
+
+def test_outgoing_transaction_succeeded(outgoing_transaction, mock_callback_api):
+    speid_id = outgoing_transaction.speid_id
+    to_process = [
+        dict(
+            speid_id=speid_id,
+            action='succeeded'
+        )
+    ]
+    process_outgoing_transactions(to_process)
+
+    transaction = Transaction.objects.get(speid_id)
+    assert transaction.estado is Estado.succeeded
+
+
+def test_outgoing_transaction_failed(outgoing_transaction, mock_callback_api):
+    speid_id = outgoing_transaction.speid_id
+    to_process = [
+        dict(
+            speid_id=speid_id,
+            action='failed'
+        )
+    ]
+    process_outgoing_transactions(to_process)
+
+    transaction = Transaction.objects.get(speid_id)
+    assert transaction.estado is Estado.failed
+
+
+def test_outgoing_transaction_doesnotexist():
+    speid_id = outgoing_transaction.speid_id
+    to_process = [
+        dict(
+            speid_id='RANDOM',
+            action='succeeded'
+        )
+    ]
+    process_outgoing_transactions(to_process)
+
+    transaction = Transaction.objects.get(speid_id)
+    assert transaction.estado is Estado.created

--- a/tests/tasks/test_transactions.py
+++ b/tests/tasks/test_transactions.py
@@ -1,8 +1,12 @@
-import pytest
 import datetime as dt
 
+import pytest
+
 from speid.models import Transaction
-from speid.tasks.transactions import execute_create_transactions, process_outgoing_transactions
+from speid.tasks.transactions import (
+    execute_create_transactions,
+    process_outgoing_transactions,
+)
 from speid.types import Estado
 from speid.validations import SpeidTransaction
 
@@ -107,43 +111,30 @@ def test_transaction_not_in_backend_but_in_speid(incoming_transactions):
     assert sent_transaction.estado == Estado.succeeded
 
 
-def test_outgoing_transaction_succeeded(outgoing_transaction, mock_callback_api):
+def test_outgoing_transaction_succeeded(
+    outgoing_transaction, mock_callback_api
+):
     speid_id = outgoing_transaction.speid_id
-    to_process = [
-        dict(
-            speid_id=speid_id,
-            action='succeeded'
-        )
-    ]
+    to_process = [dict(speid_id=speid_id, action='succeeded')]
     process_outgoing_transactions(to_process)
 
-    transaction = Transaction.objects.get(speid_id)
+    transaction = Transaction.objects.get(speid_id=speid_id)
     assert transaction.estado is Estado.succeeded
 
 
 def test_outgoing_transaction_failed(outgoing_transaction, mock_callback_api):
     speid_id = outgoing_transaction.speid_id
-    to_process = [
-        dict(
-            speid_id=speid_id,
-            action='failed'
-        )
-    ]
+    to_process = [dict(speid_id=speid_id, action='failed')]
     process_outgoing_transactions(to_process)
 
-    transaction = Transaction.objects.get(speid_id)
+    transaction = Transaction.objects.get(speid_id=speid_id)
     assert transaction.estado is Estado.failed
 
 
-def test_outgoing_transaction_doesnotexist():
+def test_outgoing_transaction_doesnotexist(outgoing_transaction):
     speid_id = outgoing_transaction.speid_id
-    to_process = [
-        dict(
-            speid_id='RANDOM',
-            action='succeeded'
-        )
-    ]
+    to_process = [dict(speid_id='RANDOM', action='succeeded')]
     process_outgoing_transactions(to_process)
 
-    transaction = Transaction.objects.get(speid_id)
+    transaction = Transaction.objects.get(speid_id=speid_id)
     assert transaction.estado is Estado.created


### PR DESCRIPTION
To process outgoing transactions, you only add the `speid_id` and the action to be executed (`succeeded`, `failed`). It sends the corresponding callback to the API

closes #126