### PR TITLE
FIx task process_outgoing_transactions

### DIFF
--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -56,10 +56,7 @@ def process_outgoing_transactions(self, transactions: list):
             continue
         else:
             transaction.estado = new_estado
-
-        callback_helper.set_status_transaction(
-            transaction.speid_id, transaction.estado.name
-        )
+        transaction.set_state(transaction.estado)
         transaction.events.append(
             Event(type=event_type, metadata=str('Reversed by recon task'))
         )

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -1,7 +1,7 @@
 from mongoengine import DoesNotExist
 from sentry_sdk import capture_exception
 
-from speid.helpers import callback_helper, transaction_helper
+from speid.helpers import transaction_helper
 from speid.models import Event, Transaction
 from speid.tasks import celery
 from speid.types import Estado, EventType


### PR DESCRIPTION
Al cambiar por queue esta tarea trata de ejecutar mediante el callback, lo único raro es que una tarea estaría poniendo datos en otra queue