### PR TITLE
enabled CANCELACION state + minor test refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8.1'
+        python-version: '3.7'
     - name: Install dependencies
       run: |
         make install-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,20 @@ jobs:
       with:
         python-version: '3.8'
     - name: Install dependencies
-      run: |
-        make install-dev
+      run: make install-dev
     - name: Lint
       run: make lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        pip install wheel
         make install-dev
     - name: Run tests
       run: |
@@ -44,7 +42,6 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          pip install wheel
           make install-dev
       - name: Generate coverage report
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
         python-version: '3.8'
     - name: Install dependencies
       run: |
-        pip install wheel
         make install-dev
     - name: Lint
       run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.8.1'
     - name: Install dependencies
       run: |
         make install-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         make install-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v1
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v1
       with:
         python-version: '3.8'
     - name: Install dependencies
@@ -23,12 +23,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v1
       with:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        pip install wheel
         make install-dev
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.8'
     - name: Install dependencies
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
+        pip install wheel
         make install-dev
     - name: Run tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ black = black -S -l 79 --target-version py37 $(PROJECT) tests
 default: install
 
 install:
-	pip install -r requirements.txt
+	pip install -r -q requirements.txt
 
 install-dev:
 	# Trying to install `flask-mongoengine` package in virtual environment of GitHub Actions

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ install:
 	pip install -r -q requirements.txt
 
 install-dev:
-	# Trying to install `flask-mongoengine` package in virtual environment of GitHub Actions
-	# fails because `wheel` package is needed to build that package. It only fails in GitHub actions
-	# Inside docker container it works Ok.
-	# The issue reportig this problem is https://github.com/MongoEngine/flask-mongoengine/issues/402
+# Trying to install `flask-mongoengine` package in virtual environment of GitHub Actions
+# fails because `wheel` package is needed to build that package. It only fails in GitHub actions
+# Inside docker container it works Ok.
+# The issue reportig this problem is https://github.com/MongoEngine/flask-mongoengine/issues/402
 	pip install -q wheel
 	$(MAKE) install
 	pip install -q -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install:
 	pip install -q -r requirements.txt
 
 install-dev: install
+	pip install wheel
 	pip install -q -r requirements-dev.txt
 
 install-test: install-dev

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ black = black -S -l 79 --target-version py37 $(PROJECT) tests
 default: install
 
 install:
-	pip install -q requirements.txt
+	pip install -r requirements.txt
 
 install-dev: install
 	pip install wheel

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ black = black -S -l 79 --target-version py37 $(PROJECT) tests
 default: install
 
 install:
-	pip install -q -r requirements.txt
+	pip install -q requirements.txt
 
 install-dev: install
 	pip install wheel

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ black = black -S -l 79 --target-version py37 $(PROJECT) tests
 default: install
 
 install:
-	pip install -r -q requirements.txt
+	pip install -q -r requirements.txt
 
 install-dev:
 # Trying to install `flask-mongoengine` package in virtual environment of GitHub Actions

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,13 @@ default: install
 install:
 	pip install -r requirements.txt
 
-install-dev: install
+install-dev:
+	# Trying to install `flask-mongoengine` package in virtual environment of GitHub Actions
+	# fails because `wheel` package is needed to build that package. It only fails in GitHub actions
+	# Inside docker container it works Ok.
+	# The issue reportig this problem is https://github.com/MongoEngine/flask-mongoengine/issues/402
 	pip install wheel
+	install
 	pip install -q -r requirements-dev.txt
 
 install-test: install-dev

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ install-dev:
 	# fails because `wheel` package is needed to build that package. It only fails in GitHub actions
 	# Inside docker container it works Ok.
 	# The issue reportig this problem is https://github.com/MongoEngine/flask-mongoengine/issues/402
-	pip install wheel
-	install
+	pip install -q wheel
+	$(MAKE) install
 	pip install -q -r requirements-dev.txt
 
 install-test: install-dev

--- a/README.md
+++ b/README.md
@@ -204,9 +204,19 @@ definido en la variable de ambiente `CALLBACK_URL` con el ID del request en la U
 
 Cuando STP responde con el resultado de la operación, se recibe en el
 servicio `/orden_events` el cual busca la transacción por el ID de la orden y
-almacena un nuevo Evento. Posteriormente se se notifica al backend haciendo un PATCH al 
+almacena un nuevo Evento. Posteriormente se notifica al backend haciendo un PATCH al 
 endpoint definido en la variable de ambiente `CALLBACK_URL` con el ID del request en la 
 URL.
+
+El estado en el que puede responder STP para una transferencia son los siguientes:
+1. `LIQUIDACION`: La transferencia fue exitosa.
+2. `DEVOLUCION`: No fue posible realizar la transferencia. Este caso aplica 
+para transferencias con destino a Instituciones participantes directos de SPEI.
+3. `CANCELACION`: No fue posible realizar la transferencia. Este caso aplica 
+para transferencias con destino a Instituciones que en su CLABE tengan el prefijo **646**, es decir, clientes de STP.
+
+Cabe aclarar que en `speid` el estado `LIQUIDACION` mapea a `succeeded`, mientras que 
+`DEVOLUCION` y `CANCELACION` mapean a `failed` para retornarse al backend.
 
 Este es el cuerpo del mensaje en RabbitMQ:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ pytest-cov==2.11.*
 pytest-mock==3.5.*
 pytest-vcr==1.0.*
 coveralls==3.0.*
+wheel==0.34.*

--- a/speid/models/transaction.py
+++ b/speid/models/transaction.py
@@ -90,6 +90,7 @@ class Transaction(Document, BaseModel):
     medio_entrega = IntField()
     prioridad = IntField()
     compound_key = StringField()
+    detalle = StringField()
 
     events = ListField(ReferenceField(Event))
 

--- a/speid/types.py
+++ b/speid/types.py
@@ -25,7 +25,9 @@ class Estado(Enum):
     @classmethod
     def get_state_from_stp(cls, stp_state: str) -> Enum:
         status_from_stp = dict(
-            LIQUIDACION=cls.succeeded, DEVOLUCION=cls.failed
+            LIQUIDACION=cls.succeeded,
+            DEVOLUCION=cls.failed,
+            CANCELACION=cls.failed,
         )
         return status_from_stp.get(stp_state, cls.error)
 

--- a/speid/views.py
+++ b/speid/views.py
@@ -23,7 +23,7 @@ def health_check():
 def create_orden_events():
     try:
         transaction = Transaction.objects.get(stp_id=request.json['id'])
-
+        transaction.detalle = str(request.json['Detalle'])
         state = Estado.get_state_from_stp(request.json['Estado'])
 
         if state is Estado.failed:

--- a/speid/views.py
+++ b/speid/views.py
@@ -23,8 +23,8 @@ def health_check():
 def create_orden_events():
     try:
         transaction = Transaction.objects.get(stp_id=request.json['id'])
-        transaction.detalle = str(request.json['Detalle'])
         state = Estado.get_state_from_stp(request.json['Estado'])
+        transaction.detalle = str(request.json.get('Detalle', ''))
 
         if state is Estado.failed:
             assert transaction.estado is not Estado.failed

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -15,7 +15,7 @@ def client():
 
 
 @pytest.fixture
-def default_outcome_transaction() -> Generator[Transaction, None, None]:
+def outcome_transaction() -> Generator[Transaction, None, None]:
     transaction = Transaction(
         stp_id=2456305,
         concepto_pago='PRUEBA',

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from typing import Generator
 
 import pytest
 
 from speid import app
+from speid.models import Transaction
 
 
 @pytest.fixture
@@ -13,8 +15,9 @@ def client():
 
 
 @pytest.fixture
-def default_outcome_transaction():
-    return dict(
+def default_outcome_transaction() -> Generator[Transaction, None, None]:
+    transaction = Transaction(
+        stp_id=2456305,
         concepto_pago='PRUEBA',
         institucion_ordenante='90646',
         cuenta_beneficiario='072691004495711499',
@@ -28,6 +31,9 @@ def default_outcome_transaction():
         speid_id='go' + datetime.now().strftime('%m%d%H%M%S'),
         version=1,
     )
+    transaction.save()
+    yield transaction
+    transaction.delete()
 
 
 @pytest.fixture

--- a/tests/views/test_general.py
+++ b/tests/views/test_general.py
@@ -80,7 +80,6 @@ def test_invalid_order_event(client, default_outcome_transaction):
 
     trx = Transaction.objects.get(id=default_outcome_transaction.id)
     assert trx.estado is Estado.created
-    trx.delete()
 
 
 def test_invalid_id_order_event(client, default_outcome_transaction):
@@ -91,7 +90,6 @@ def test_invalid_id_order_event(client, default_outcome_transaction):
 
     trx = Transaction.objects.get(id=default_outcome_transaction.id)
     assert trx.estado is Estado.created
-    trx.delete()
 
 
 @pytest.mark.usefixtures('mock_callback_queue')
@@ -114,7 +112,6 @@ def test_order_event_duplicated(client, default_outcome_transaction):
 
     trx = Transaction.objects.get(id=default_outcome_transaction.id)
     assert trx.estado is Estado.failed
-    trx.delete()
 
 
 @pytest.mark.usefixtures('mock_callback_queue')

--- a/tests/views/test_general.py
+++ b/tests/views/test_general.py
@@ -18,99 +18,93 @@ def test_health_check(client):
 
 
 @pytest.mark.usefixtures('mock_callback_queue')
-def test_create_order_event(client, default_outcome_transaction):
+def test_create_order_event(client, outcome_transaction):
     data = dict(
-        id=default_outcome_transaction.stp_id,
-        Estado='LIQUIDACION',
-        Detalle="0",
+        id=outcome_transaction.stp_id, Estado='LIQUIDACION', Detalle="0",
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.succeeded
 
 
 @pytest.mark.usefixtures('mock_callback_queue')
-def test_create_order_event_failed_twice(client, default_outcome_transaction):
+def test_create_order_event_failed_twice(client, outcome_transaction):
     data = dict(
-        id=default_outcome_transaction.stp_id, Estado='DEVOLUCION', Detalle="0"
+        id=outcome_transaction.stp_id, Estado='DEVOLUCION', Detalle="0"
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.failed
 
     num_events = len(trx.events)
     data = dict(
-        id=default_outcome_transaction.stp_id, Estado='DEVOLUCION', Detalle="0"
+        id=outcome_transaction.stp_id, Estado='DEVOLUCION', Detalle="0"
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.failed
     assert len(trx.events) == num_events
 
 
 @pytest.mark.usefixtures('mock_callback_queue')
-def test_cancelled_transaction(client, default_outcome_transaction) -> None:
+def test_cancelled_transaction(client, outcome_transaction) -> None:
     data = dict(
-        id=default_outcome_transaction.stp_id,
-        Estado='CANCELACION',
-        Detalle="0",
+        id=outcome_transaction.stp_id, Estado='CANCELACION', Detalle="0",
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.failed
 
 
-def test_invalid_order_event(client, default_outcome_transaction):
+def test_invalid_order_event(client, outcome_transaction):
     data = dict(Estado='LIQUIDACION', Detalle="0")
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.created
 
 
-def test_invalid_id_order_event(client, default_outcome_transaction):
+def test_invalid_id_order_event(client, outcome_transaction):
     data = dict(id='9', Estado='LIQUIDACION', Detalle="0")
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.created
 
 
 @pytest.mark.usefixtures('mock_callback_queue')
-def test_order_event_duplicated(client, default_outcome_transaction):
+def test_order_event_duplicated(client, outcome_transaction):
     data = dict(
-        id=default_outcome_transaction.stp_id,
-        Estado='LIQUIDACION',
-        Detalle="0",
+        id=outcome_transaction.stp_id, Estado='LIQUIDACION', Detalle="0",
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
     data = dict(
-        id=default_outcome_transaction.stp_id, Estado='DEVOLUCION', Detalle="0"
+        id=outcome_transaction.stp_id, Estado='DEVOLUCION', Detalle="0"
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
     assert resp.data == "got it!".encode()
 
-    trx = Transaction.objects.get(id=default_outcome_transaction.id)
+    trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.failed
 
 

--- a/tests/views/test_general.py
+++ b/tests/views/test_general.py
@@ -58,7 +58,9 @@ def test_create_order_event_failed_twice(client, outcome_transaction):
 @pytest.mark.usefixtures('mock_callback_queue')
 def test_cancelled_transaction(client, outcome_transaction) -> None:
     data = dict(
-        id=outcome_transaction.stp_id, Estado='CANCELACION', Detalle=0,
+        id=outcome_transaction.stp_id,
+        Estado='CANCELACION',
+        Detalle='something went wrong',
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
@@ -66,7 +68,7 @@ def test_cancelled_transaction(client, outcome_transaction) -> None:
 
     trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.failed
-    assert trx.detalle == '0'
+    assert trx.detalle == 'something went wrong'
 
 
 def test_invalid_order_event(client, outcome_transaction):

--- a/tests/views/test_general.py
+++ b/tests/views/test_general.py
@@ -58,7 +58,7 @@ def test_create_order_event_failed_twice(client, outcome_transaction):
 @pytest.mark.usefixtures('mock_callback_queue')
 def test_cancelled_transaction(client, outcome_transaction) -> None:
     data = dict(
-        id=outcome_transaction.stp_id, Estado='CANCELACION', Detalle="0",
+        id=outcome_transaction.stp_id, Estado='CANCELACION', Detalle=0,
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
@@ -66,6 +66,7 @@ def test_cancelled_transaction(client, outcome_transaction) -> None:
 
     trx = Transaction.objects.get(id=outcome_transaction.id)
     assert trx.estado is Estado.failed
+    assert trx.detalle == '0'
 
 
 def test_invalid_order_event(client, outcome_transaction):

--- a/tests/views/test_general.py
+++ b/tests/views/test_general.py
@@ -20,7 +20,9 @@ def test_health_check(client):
 @pytest.mark.usefixtures('mock_callback_queue')
 def test_create_order_event(client, outcome_transaction):
     data = dict(
-        id=outcome_transaction.stp_id, Estado='LIQUIDACION', Detalle="0",
+        id=outcome_transaction.stp_id,
+        Estado='LIQUIDACION',
+        Detalle="0",
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200
@@ -94,7 +96,9 @@ def test_invalid_id_order_event(client, outcome_transaction):
 @pytest.mark.usefixtures('mock_callback_queue')
 def test_order_event_duplicated(client, outcome_transaction):
     data = dict(
-        id=outcome_transaction.stp_id, Estado='LIQUIDACION', Detalle="0",
+        id=outcome_transaction.stp_id,
+        Estado='LIQUIDACION',
+        Detalle="0",
     )
     resp = client.post('/orden_events', json=data)
     assert resp.status_code == 200


### PR DESCRIPTION
- added `CANCELACION` state which is the state for transactions like "TRASPASO CANCELADO". This state marks the transaction as `failed`
- fixture `default_outcome_transaction` refactor