### PR TITLE
downgrade celery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 blinker==1.4
 boto3==1.16.*
-celery==5.0.5
+celery==4.4.6
 Flask==1.1.2
 flask-mongoengine==1.0.0
 luhnmod10==1.0.2


### PR DESCRIPTION
We are downgrade for now, and test if just is -A the problem

```bash
ERROR -- : The support for this usage was removed in Celery 5.0. Instead you should use `-A` as a global option:
ERROR -- : celery -A celeryapp worker <...>
ERROR -- : Usage: celery worker [OPTIONS]
ERROR -- : Try 'celery worker --help' for help.
ERROR -- :
ERROR -- : Error: no such option: -A
```