### PR TITLE
mark transfer as failed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pandas==1.2.0
 python-hosts==1.0.1
 sentry-sdk==0.19.5
 pydantic==1.7.3
-stpmex==3.7.2
+stpmex==3.7.4

--- a/speid/tasks/orders.py
+++ b/speid/tasks/orders.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import clabe
 import luhnmod10
 from mongoengine import DoesNotExist
+from pydantic import ValidationError
 from sentry_sdk import capture_exception
 from stpmex.exc import InvalidAccountType
 
@@ -100,6 +101,6 @@ def execute(order_val: dict):
         # Return transaction after 2 hours of creation
         assert (now - transaction.created_at) < timedelta(hours=2)
         transaction.create_order()
-    except (AssertionError, InvalidAccountType):
+    except (AssertionError, InvalidAccountType, ValidationError):
         transaction.set_state(Estado.failed)
         transaction.save()


### PR DESCRIPTION
marks transfers as `failed` when bank code is blocked. 
related to: https://github.com/cuenca-mx/stpmex-python/issues/154