### PR TITLE
Retrying stuck in speid

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:warnings -v --cov=speid

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --ignore=src/heimdall/tests -p no:warnings -v --cov-report term-missing --cov=cuenca
+addopts = -p no:warnings -v --cov-report term-missing --cov=speid
 
 [aliases]
 test=pytest
@@ -15,3 +15,14 @@ line_length=79
 
 [mypy]
 ignore_missing_imports = true
+
+[coverage:run]
+source = speid
+branch = True
+omit = tests/*,venv/*
+
+[coverage:report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/speid/__init__.py
+++ b/speid/__init__.py
@@ -23,7 +23,7 @@ class CJSONEncoder(json.JSONEncoder):
         else:
             try:
                 encoded = o.to_dict()
-            except AttributeError:
+            except AttributeError:  # pragma: no cover
                 encoded = super().default(o)
         return encoded
 

--- a/speid/commands/spei.py
+++ b/speid/commands/spei.py
@@ -50,4 +50,4 @@ def re_execute_transactions(speid_id):
 
 
 if __name__ == "__main__":
-    re_execute_transactions()  # pragma: nocover
+    re_execute_transactions()  # pragma: no cover

--- a/speid/models/helpers.py
+++ b/speid/models/helpers.py
@@ -192,7 +192,7 @@ def mongo_to_python_type(field, data):
         rv = data.isoformat()
     elif field_type is ComplexDateTimeField:
         rv = field.to_python(data).isoformat()
-    elif rv is FloatField:
+    elif field_type is FloatField:
         rv = float(data)
     elif field_type is IntField:
         rv = int(data)

--- a/speid/tasks/accounts.py
+++ b/speid/tasks/accounts.py
@@ -51,7 +51,7 @@ def update_account(self, account_dict: dict) -> None:
     except ValidationError as exc:
         capture_exception(exc)
     except DoesNotExist:
-        create_account.apply((account_dict,))
+        create_account.apply_async((account_dict,))
     except Exception as exc:
         capture_exception(exc)
         self.retry(countdown=COUNTDOWN, exc=exc)

--- a/speid/tasks/orders.py
+++ b/speid/tasks/orders.py
@@ -6,7 +6,13 @@ import luhnmod10
 from mongoengine import DoesNotExist
 from pydantic import ValidationError
 from sentry_sdk import capture_exception
-from stpmex.exc import InvalidAccountType, InvalidTrackingKey
+from stpmex.exc import (
+    InvalidAccountType,
+    InvalidAmount,
+    InvalidInstitution,
+    InvalidTrackingKey,
+    PldRejected,
+)
 
 from speid.exc import (
     MalformedOrderException,
@@ -105,6 +111,9 @@ def execute(order_val: dict):
         InvalidAccountType,
         InvalidTrackingKey,
         ValidationError,
+        PldRejected,
+        InvalidInstitution,
+        InvalidAmount,
     ):
         transaction.set_state(Estado.failed)
         transaction.save()

--- a/speid/tasks/orders.py
+++ b/speid/tasks/orders.py
@@ -109,11 +109,11 @@ def execute(order_val: dict):
     except (
         AssertionError,
         InvalidAccountType,
-        InvalidTrackingKey,
-        ValidationError,
-        PldRejected,
-        InvalidInstitution,
         InvalidAmount,
+        InvalidInstitution,
+        InvalidTrackingKey,
+        PldRejected,
+        ValidationError,
     ):
         transaction.set_state(Estado.failed)
         transaction.save()

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -35,7 +35,7 @@ def execute_create_incoming_transactions(transactions: list):
 
 
 @celery.task
-def retry_incoming_transactions(self, speid_ids: List[str]) -> None:
+def retry_incoming_transactions(speid_ids: List[str]) -> None:
     for speid_id in speid_ids:
         transaction = Transaction.objects.get(speid_id=speid_id)
         transaction.confirm_callback_transaction()

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -1,3 +1,4 @@
+from typing import List
 from mongoengine import DoesNotExist
 from sentry_sdk import capture_exception
 
@@ -33,9 +34,9 @@ def execute_create_incoming_transactions(transactions: list):
             transaction_helper.process_incoming_transaction(transaction)
 
 
-@celery.task(bind=True, max_retries=5)
-def retry_incoming_transactions(self, transactions: list):
-    for speid_id in transactions:
+@celery.task()
+def retry_incoming_transactions(self, speid_ids: List[str]) -> None:
+    for speid_id in speid_ids:
         transaction = Transaction.objects.get(speid_id=speid_id)
         transaction.confirm_callback_transaction()
         transaction.save()

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -36,11 +36,7 @@ def execute_create_incoming_transactions(transactions: list):
 @celery.task(bind=True, max_retries=5)
 def retry_incoming_transactions(self, transactions: list):
     for speid_id in transactions:
-        try:
-            transaction = Transaction.objects.get(speid_id=speid_id)
-        except DoesNotExist as ex:
-            capture_exception(ex)
-            continue
+        transaction = Transaction.objects.get(speid_id=speid_id)
         transaction.confirm_callback_transaction()
         transaction.save()
 

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -1,37 +1,10 @@
 from typing import List
 
 from mongoengine import DoesNotExist
-from sentry_sdk import capture_exception
 
-from speid.helpers import transaction_helper
 from speid.models import Event, Transaction
 from speid.tasks import celery
 from speid.types import Estado, EventType
-
-
-@celery.task(bind=True, max_retries=5)
-def create_incoming_transactions(self, transactions: list):
-    try:
-        execute_create_incoming_transactions(transactions)
-    except Exception as e:
-        capture_exception(e)
-        self.retry(countdown=600, exc=e)
-
-
-def execute_create_incoming_transactions(transactions: list):
-    for transaction in transactions:
-        try:
-            previous_transaction = Transaction.objects.get(
-                clave_rastreo=transaction['ClaveRastreo'],
-                fecha_operacion=transaction['FechaOperacion'],
-            )
-            if previous_transaction.estado == Estado.error:
-                # Not in backend
-                previous_transaction.confirm_callback_transaction()
-                previous_transaction.save()
-        except DoesNotExist:
-            # Not in speid
-            transaction_helper.process_incoming_transaction(transaction)
 
 
 @celery.task

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -34,14 +34,15 @@ def execute_create_incoming_transactions(transactions: list):
 
 
 @celery.task(bind=True, max_retries=5)
-def resend_incoming_transactions(self, transactions: list):
+def retry_incoming_transactions(self, transactions: list):
     for speid_id in transactions:
         try:
             transaction = Transaction.objects.get(speid_id=speid_id)
-            transaction.confirm_callback_transaction()
-            transaction.save()
         except DoesNotExist as ex:
             capture_exception(ex)
+            continue
+        transaction.confirm_callback_transaction()
+        transaction.save()
 
 
 @celery.task(bind=True)

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -2,7 +2,6 @@ from typing import List
 from mongoengine import DoesNotExist
 from sentry_sdk import capture_exception
 
-import speid
 from speid.helpers import transaction_helper
 from speid.models import Event, Transaction
 from speid.tasks import celery

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -11,6 +11,7 @@ from speid.types import Estado, EventType
 def retry_incoming_transactions(speid_ids: List[str]) -> None:
     for speid_id in speid_ids:
         transaction = Transaction.objects.get(speid_id=speid_id)
+        transaction.events.append(Event(type=EventType.retry))
         transaction.confirm_callback_transaction()
         transaction.save()
 

--- a/speid/tasks/transactions.py
+++ b/speid/tasks/transactions.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from mongoengine import DoesNotExist
 from sentry_sdk import capture_exception
 
@@ -33,7 +34,7 @@ def execute_create_incoming_transactions(transactions: list):
             transaction_helper.process_incoming_transaction(transaction)
 
 
-@celery.task()
+@celery.task
 def retry_incoming_transactions(self, speid_ids: List[str]) -> None:
     for speid_id in speid_ids:
         transaction = Transaction.objects.get(speid_id=speid_id)

--- a/tests/models/test_helpers.py
+++ b/tests/models/test_helpers.py
@@ -16,6 +16,7 @@ from mongoengine import (
 )
 
 from speid.models.base import BaseModel
+from speid.models.helpers import base62_encode, mongo_to_dict
 
 
 def test_doc_to_dict():
@@ -52,6 +53,7 @@ def test_doc_to_dict():
         additional_info = DictField()
         created_at = DateTimeField(default=datetime.now)
         updated_at = ComplexDateTimeField(default=datetime.now)
+        length = FloatField()
 
     serie = Series(
         title="Some Random Series",
@@ -78,6 +80,7 @@ def test_doc_to_dict():
         info=DataSheet(year="2019", author="Kaiu", rank=4.4),
         secret_code="super_secret_code",
         additional_info={"data": "he63oc48r5jv"},
+        length=1.5,
     )
 
     serie.save()
@@ -98,3 +101,12 @@ def test_doc_to_dict():
     assert type(res["additional_info"]) is dict
     assert type(res["created_at"]) is str
     assert type(res["updated_at"]) is str
+    assert type(res["length"]) is float
+
+
+def test_doc_to_dict_none():
+    assert mongo_to_dict(None) is None
+
+
+def test_base_62_encode():
+    assert base62_encode(0) == '0'

--- a/tests/tasks/test_accounts.py
+++ b/tests/tasks/test_accounts.py
@@ -233,7 +233,7 @@ def test_update_account_failed_with_validation_error_raised(
 
 @patch('speid.tasks.accounts.capture_exception')
 @patch('speid.tasks.accounts.update_account.retry')
-@patch('speid.tasks.accounts.create_account.apply')
+@patch('speid.tasks.accounts.create_account.apply_async')
 def test_update_account_does_not_exists_then_create_account(
     mock_apply: MagicMock,
     mock_retry: MagicMock,

--- a/tests/tasks/test_orders.py
+++ b/tests/tasks/test_orders.py
@@ -9,8 +9,15 @@ from speid.exc import (
     ScheduleError,
 )
 from speid.models import Transaction
-from speid.tasks.orders import execute, send_order
+from speid.tasks.orders import execute, retry_timeout, send_order
 from speid.types import Estado, EventType
+
+
+@pytest.mark.parametrize(
+    'attempts, expected', [(1, 2), (5, 10), (10, 1200), (15, 1200)]
+)
+def test_retry_timeout(attempts, expected):
+    assert retry_timeout(attempts) == expected
 
 
 def test_worker_with_incorrect_version(

--- a/tests/tasks/test_transactions.py
+++ b/tests/tasks/test_transactions.py
@@ -1,12 +1,10 @@
 import datetime as dt
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from speid.models import Transaction
 from speid.tasks.transactions import (
-    create_incoming_transactions,
-    execute_create_incoming_transactions,
     process_outgoing_transactions,
     retry_incoming_transactions,
 )
@@ -81,56 +79,6 @@ def outgoing_transaction():
     yield transaction
 
     transaction.delete()
-
-
-@pytest.mark.vcr
-def test_transaction_not_in_speid(incoming_transactions, mock_callback_queue):
-    create_incoming_transactions(incoming_transactions)
-
-    saved_transaction = Transaction.objects.get(
-        clave_rastreo=incoming_transactions[0]['ClaveRastreo']
-    )
-    assert saved_transaction.estado == Estado.succeeded
-
-
-@patch('speid.tasks.transactions.capture_exception')
-@patch('speid.tasks.transactions.create_incoming_transactions.retry')
-def test_retry_on_exception(
-    mock_retry: MagicMock,
-    mock_capture_exception: MagicMock,
-    incoming_transactions,
-):
-    with patch(
-        'speid.tasks.transactions.execute_create_incoming_transactions',
-        side_effect=Exception(),
-    ):
-        create_incoming_transactions(incoming_transactions)
-
-    mock_capture_exception.assert_called_once()
-    mock_retry.assert_called_once()
-
-
-@pytest.mark.vcr
-def test_transaction_not_in_backend_but_in_speid(
-    incoming_transactions, mock_callback_queue
-):
-    execute_create_incoming_transactions(incoming_transactions)
-
-    saved_transaction = Transaction.objects.get(
-        clave_rastreo=incoming_transactions[0]['ClaveRastreo']
-    )
-
-    assert saved_transaction.estado == Estado.succeeded
-    saved_transaction.estado = Estado.error
-    saved_transaction.save()
-
-    execute_create_incoming_transactions([incoming_transactions[0]])
-
-    sent_transaction = Transaction.objects.get(
-        clave_rastreo=saved_transaction.clave_rastreo
-    )
-
-    assert sent_transaction.estado == Estado.succeeded
 
 
 def test_outgoing_transaction_succeeded(

--- a/tests/tasks/test_transactions.py
+++ b/tests/tasks/test_transactions.py
@@ -8,6 +8,7 @@ from speid.tasks.transactions import (
     create_incoming_transactions,
     execute_create_incoming_transactions,
     process_outgoing_transactions,
+    retry_incoming_transactions,
 )
 from speid.types import Estado, EventType
 from speid.validations import SpeidTransaction
@@ -195,3 +196,14 @@ def test_outgoing_transaction_doesnotexist(outgoing_transaction):
 
     transaction = Transaction.objects.get(speid_id=speid_id)
     assert transaction.estado is Estado.created
+
+
+def test_outgoing_transaction_retry_core(
+    outgoing_transaction, mock_callback_queue
+):
+    speid_id = outgoing_transaction.speid_id
+    with patch(
+        'speid.tasks.transactions.Transaction.confirm_callback_transaction'
+    ) as method_mock:
+        retry_incoming_transactions(speid_ids=[speid_id])
+    method_mock.assert_called_once()


### PR DESCRIPTION
vuelve a mandar transacciones existentes a core
corrige bug que creaba transacciones en succeeded aunque fallaran
agrega los errores de pld rejected y invalid amount a los que se regresan automáticamente a core
- closes #321
- closes #294 
- closes #322 