### PR TITLE
using mongoengine==0.23.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@ celery==5.2.3
 Flask==2.0.3
 flask-mongoengine==1.0.0
 luhnmod10==1.0.2
+mongoengine==0.23.1
 newrelic==6.2.0.156
 pandas==1.2.4
+pydantic==1.7.4
 python-hosts==1.0.1
 sentry-sdk==0.19.5
-pydantic==1.7.4
 stpmex==3.7.6


### PR DESCRIPTION
Al recrear la imágen de speid con la nueva versión de Flask y Celery se actualizaron las siguientes dependencias:
```
mongoengine==0.24.0
pymongo==4.0
```
Pymongo 4.0 tiene un bug que provoca[ AutoReconnect](https://www.mongodb.com/community/forums/t/pymongo-4-0-1-released/135979). Lo ideal sería cambiar a pymongo 4.0.1 pero mongoengine tiene conflictos de versión de dependencias.

https://github.com/MongoEngine/mongoengine/issues/2624



Se fija la dependencia de `mongoengine==0.23.1` la cual es compatible con `pymongo==3.X`. Por ahora vamos a mantener esta versión hasta que mongoengine soporte la nueva



closes #335 

