### PR TITLE
Downgrade Importlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas==1.2.4
 python-hosts==1.0.1
 sentry-sdk==0.19.5
 stpmex==3.10.0
+importlib-metadata==4.13.0


### PR DESCRIPTION
An error with a deprecated endpoint in importlib 5, causes the following error:
`AttributeError: 'EntryPoints' object has no attribute 'get'`

fix: https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean