### PR TITLE
PLD Blocking accounts

### DIFF
--- a/speid/models/transaction.py
+++ b/speid/models/transaction.py
@@ -154,10 +154,12 @@ class Transaction(Document, BaseModel):
             account = Account.objects.get(cuenta=self.cuenta_beneficiario)
             if account.is_restricted:
                 ordenante = self.rfc_curp_ordenante
-                is_valid = (
-                    ordenante == account.allowed_rfc
-                    or ordenante == account.allowed_curp
-                ) and self.monto >= MIN_AMOUNT
+                is_valid = all([
+                    (ordenante == account.allowed_rfc
+                    or ordenante == account.allowed_curp),
+                    self.monto >= MIN_AMOUNT,
+                    account.estado != Estado.pld_blocked,
+                ])
         except DoesNotExist:
             pass
         return is_valid

--- a/speid/types.py
+++ b/speid/types.py
@@ -22,6 +22,7 @@ class Estado(str, Enum):
     rejected = 'rejected'
     error = 'error'  # Malformed order
     deactivated = 'deactivated'
+    pld_blocked = 'pld_blocked'  # Blocked but not deactivated
 
     @classmethod
     def get_state_from_stp(cls, stp_state: str) -> Enum:

--- a/tests/tasks/test_accounts.py
+++ b/tests/tasks/test_accounts.py
@@ -8,6 +8,7 @@ from stpmex.exc import InvalidRfcOrCurp
 from speid.models import PhysicalAccount
 from speid.models.account import MoralAccount
 from speid.tasks.accounts import (
+    block_account,
     create_account,
     deactivate_account,
     execute_create_account,
@@ -339,4 +340,23 @@ def test_deactivate_account_doesnot_exist(
     mock_retry: MagicMock,
 ):
     deactivate_account('646180157000011122')
+    mock_retry.assert_not_called()
+
+
+@patch('speid.tasks.accounts.block_account.retry')
+def test_block_account(
+    mock_retry: MagicMock, moral_account: MoralAccount,
+):
+    assert moral_account.estado == Estado.succeeded
+    block_account(moral_account.cuenta)
+    moral_account.reload()
+    assert moral_account.estado == Estado.pld_blocked
+    mock_retry.assert_not_called()
+
+
+@patch('speid.tasks.accounts.block_account.retry')
+def test_block_account_doesnot_exist(
+    mock_retry: MagicMock,
+):
+    block_account('646180157000011122')
     mock_retry.assert_not_called()

--- a/tests/views/test_general.py
+++ b/tests/views/test_general.py
@@ -240,7 +240,7 @@ def test_create_incoming_restricted_account(
 ):
     """
     Validate reject a depoist to restricted account if the
-    curp_rfc does not match with ordeenante
+    curp_rfc does not match with ordenante
     """
     default_income_transaction['CuentaBeneficiario'] = moral_account.cuenta
     moral_account.is_restricted = True
@@ -265,8 +265,25 @@ def test_create_incoming_restricted_account(
     assert resp.json['estado'] == 'DEVOLUCION'
     transaction.delete()
 
-    # curp and monto match, the transaction is approve, at least $100.0
+    # Curp Match and Monto match but account is blocked. 
+    # The transaction is rejected
+    default_income_transaction['Monto'] = 100.00
+    default_income_transaction['RFCCurpOrdenante'] = moral_account.allowed_curp
+    default_income_transaction['ClaveRastreo'] = 'PRUEBATAMIZI2'
+    moral_account.estado = Estado.pld_blocked
+    moral_account.save()
+    resp = client.post('/ordenes', json=default_income_transaction)
+    transaction = Transaction.objects.order_by('-created_at').first()
+    assert transaction.estado is Estado.rejected
+    assert resp.status_code == 201
+    assert resp.json['estado'] == 'DEVOLUCION'
+    transaction.delete()
+
+    # curp, monto match and account is succeeded
+    # the transaction is approve, at least $100.0
     default_income_transaction['Monto'] = 100.0
+    moral_account.estado = Estado.succeeded
+    moral_account.save()
     resp = client.post('/ordenes', json=default_income_transaction)
     transaction = Transaction.objects.order_by('-created_at').first()
     assert resp.status_code == 201


### PR DESCRIPTION
## Contexto

Bloquear una cuenta: No permitir que salga ni entre dinero de esta. Esto no implica que la cuenta esté dada de baja en STP

Actualmente no se puede bloquear una cuenta para recibir transacciones. La única manera es cambiando la información del `allowed_rfc` y `allowed_curp` de la cuenta del cliente.

## Solución

Nuevo estado `pld_blocked`
En cuanto una cuenta entre en bloqueo por PLD, llega una task que bloquea la cuenta sin darla de baja en STP.
Cuando llegue una orden nueva: si la cuenta está bloqueada, se regresa el dinero.