### PR TITLE
Wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mongoengine==0.23.1
 newrelic==6.2.0.156
 pandas==1.2.4
 python-hosts==1.0.1
-sentry-sdk==0.19.5
+sentry-sdk==1.14.0
 stpmex==3.11.1
 importlib-metadata==4.13.0
+wheel==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mongoengine==0.23.1
 newrelic==6.2.0.156
 pandas==1.2.4
 python-hosts==1.0.1
-sentry-sdk==1.14.0
+sentry-sdk==0.19.5
 stpmex==3.11.1
 importlib-metadata==4.13.0
+wheel==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ python-hosts==1.0.1
 sentry-sdk==0.19.5
 stpmex==3.11.1
 importlib-metadata==4.13.0
-wheel==0.40.0


### PR DESCRIPTION
pypa/wheel vulnerable to Regular Expression denial of service (ReDoS) #2


Python Packaging Authority (PyPA) Wheel is a reference implementation of the Python wheel packaging standard. Wheel 0.37.1 and earlier are vulnerable to a Regular Expression denial of service via attacker controlled input to the wheel cli. The vulnerable regex is used to verify the validity of Wheel file names. This has been patched in version 0.38.1.

