### PR TITLE
Fix cli group

### DIFF
--- a/speid/commands/spei.py
+++ b/speid/commands/spei.py
@@ -9,10 +9,9 @@ from speid.types import Estado, EventType
 @click.group('speid')
 def speid_group():
     """Perform speid actions."""
-    pass
 
 
-@speid_group.command('callback-spei-transaction')
+@speid_group.command()
 @click.argument('transaction_id', type=str)
 @click.argument('transaction_status', type=str)
 def callback_spei_transaction(transaction_id, transaction_status):
@@ -34,7 +33,7 @@ def callback_spei_transaction(transaction_id, transaction_status):
     transaction.save()
 
 
-@speid_group.command('re-execute-transactions')
+@speid_group.command()
 @click.argument('speid_id', type=str)
 def re_execute_transactions(speid_id):
     """Retry send a transaction to STP, it takes the values

--- a/speid/commands/spei.py
+++ b/speid/commands/spei.py
@@ -1,12 +1,12 @@
 import click
 from mongoengine import DoesNotExist
-
+from speid import app
 from speid.helpers.callback_helper import set_status_transaction
 from speid.models import Event, Transaction
 from speid.types import Estado, EventType
 
 
-@click.group('speid')
+@app.cli.group('speid')
 def speid_group():
     """Perform speid actions."""
 

--- a/speid/commands/spei.py
+++ b/speid/commands/spei.py
@@ -1,5 +1,6 @@
 import click
 from mongoengine import DoesNotExist
+
 from speid import app
 from speid.helpers.callback_helper import set_status_transaction
 from speid.models import Event, Transaction
@@ -11,7 +12,7 @@ def speid_group():
     """Perform speid actions."""
 
 
-@speid_group.command()
+@speid_group.command('callback-spei-transaction')
 @click.argument('transaction_id', type=str)
 @click.argument('transaction_status', type=str)
 def callback_spei_transaction(transaction_id, transaction_status):
@@ -33,7 +34,7 @@ def callback_spei_transaction(transaction_id, transaction_status):
     transaction.save()
 
 
-@speid_group.command()
+@speid_group.command('re-execute-transactions')
 @click.argument('speid_id', type=str)
 def re_execute_transactions(speid_id):
     """Retry send a transaction to STP, it takes the values

--- a/tests/commands/test_spei.py
+++ b/tests/commands/test_spei.py
@@ -27,13 +27,12 @@ def transaction():
     transaction.delete()
 
 
-def test_callback_spei_transaction(mock_callback_queue, transaction):
+def test_callback_spei_transaction(runner, mock_callback_queue, transaction):
     id_trx = transaction.id
     assert transaction.estado is Estado.created
 
-    runner = CliRunner()
     runner.invoke(
-        speid_group, ['callback_spei_transaction', str(id_trx), 'succeeded']
+        speid_group, ['callback-spei-transaction', str(id_trx), 'succeeded']
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -42,13 +41,14 @@ def test_callback_spei_transaction(mock_callback_queue, transaction):
     assert transaction.events[-1].metadata == 'Reversed by SPEID command'
 
 
-def test_callback_spei_failed_transaction(mock_callback_queue, transaction):
+def test_callback_spei_failed_transaction(
+    runner, mock_callback_queue, transaction
+):
     id_trx = transaction.id
     assert transaction.estado is Estado.created
 
-    runner = CliRunner()
     runner.invoke(
-        speid_group, ['callback_spei_transaction', str(id_trx), 'failed']
+        speid_group, ['callback-spei-transaction', str(id_trx), 'failed']
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -57,13 +57,14 @@ def test_callback_spei_failed_transaction(mock_callback_queue, transaction):
     assert transaction.events[-1].metadata == 'Reversed by SPEID command'
 
 
-def test_callback_spei_invalid_transaction(mock_callback_queue, transaction):
+def test_callback_spei_invalid_transaction(
+    runner, mock_callback_queue, transaction
+):
     id_trx = transaction.id
     assert transaction.estado is Estado.created
 
-    runner = CliRunner()
     result = runner.invoke(
-        speid_group, ['callback_spei_transaction', str(id_trx), 'invalid']
+        speid_group, ['callback-spei-transaction', str(id_trx), 'invalid']
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -76,9 +77,8 @@ def test_re_execute_transactions(runner, transaction, physical_account):
     id_trx = transaction.id
     assert transaction.estado is Estado.created
 
-    runner = CliRunner()
     runner.invoke(
-        speid_group, ['re_execute_transactions', transaction.speid_id]
+        speid_group, ['re-execute-transactions', transaction.speid_id]
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -93,9 +93,8 @@ def test_re_execute_transaction_not_found(
     id_trx = transaction.id
     assert transaction.estado is Estado.created
 
-    runner = CliRunner()
     result = runner.invoke(
-        speid_group, ['re_execute_transactions', 'invalid_speid_id']
+        speid_group, ['re-execute-transactions', 'invalid_speid_id']
     )
     transaction = Transaction.objects.get(id=id_trx)
 

--- a/tests/commands/test_spei.py
+++ b/tests/commands/test_spei.py
@@ -1,5 +1,4 @@
 import pytest
-from click.testing import CliRunner
 
 from speid.commands.spei import speid_group
 from speid.models import Transaction

--- a/tests/commands/test_spei.py
+++ b/tests/commands/test_spei.py
@@ -33,7 +33,7 @@ def test_callback_spei_transaction(mock_callback_queue, transaction):
 
     runner = CliRunner()
     runner.invoke(
-        speid_group, ['callback-spei-transaction', str(id_trx), 'succeeded']
+        speid_group, ['callback_spei_transaction', str(id_trx), 'succeeded']
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -48,7 +48,7 @@ def test_callback_spei_failed_transaction(mock_callback_queue, transaction):
 
     runner = CliRunner()
     runner.invoke(
-        speid_group, ['callback-spei-transaction', str(id_trx), 'failed']
+        speid_group, ['callback_spei_transaction', str(id_trx), 'failed']
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -63,7 +63,7 @@ def test_callback_spei_invalid_transaction(mock_callback_queue, transaction):
 
     runner = CliRunner()
     result = runner.invoke(
-        speid_group, ['callback-spei-transaction', str(id_trx), 'invalid']
+        speid_group, ['callback_spei_transaction', str(id_trx), 'invalid']
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -78,7 +78,7 @@ def test_re_execute_transactions(runner, transaction, physical_account):
 
     runner = CliRunner()
     runner.invoke(
-        speid_group, ['re-execute-transactions', transaction.speid_id]
+        speid_group, ['re_execute_transactions', transaction.speid_id]
     )
 
     transaction = Transaction.objects.get(id=id_trx)
@@ -95,7 +95,7 @@ def test_re_execute_transaction_not_found(
 
     runner = CliRunner()
     result = runner.invoke(
-        speid_group, ['re-execute-transactions', 'invalid_speid_id']
+        speid_group, ['re_execute_transactions', 'invalid_speid_id']
     )
     transaction = Transaction.objects.get(id=id_trx)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from celery import Celery
 from flask.testing import FlaskCliRunner
+
 from speid import app
 from speid.models import Transaction
 from speid.types import TipoTransaccion

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,19 @@ from unittest.mock import patch
 
 import pytest
 from celery import Celery
+from flask.testing import FlaskCliRunner
 
 from speid.models import Transaction
 from speid.types import TipoTransaccion
 
 SEND_TRANSACTION_TASK = os.environ['SEND_TRANSACTION_TASK']
 SEND_STATUS_TRANSACTION_TASK = os.environ['SEND_STATUS_TRANSACTION_TASK']
+
+
+@pytest.fixture
+def runner():
+    runner = FlaskCliRunner(app)
+    return runner
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from celery import Celery
 from flask.testing import FlaskCliRunner
-
+from speid import app
 from speid.models import Transaction
 from speid.types import TipoTransaccion
 


### PR DESCRIPTION
We migrated from Flask 2.2.5 and the command interface broke. This pull request fixes the issue, and the commands are now functional again